### PR TITLE
correctly handle XDG_CONFIG_HOME if string does not end with '/'

### DIFF
--- a/src/storage.c
+++ b/src/storage.c
@@ -78,21 +78,21 @@ int storage_path(char *out, size_t length) {
 
 	const char *path;
 
-	if (length > PATH_MAX) length = PATH_MAX;
+        if (length > PATH_MAX) length = PATH_MAX;
 
-	path = getenv("XDG_CONFIG_HOME");
+        path = getenv("XDG_CONFIG_HOME");
+        if (path && *path) {
+                unsigned int i = strlcpy(out, path, length);
+                if (i + 1 >= length) return -1; /* path too long */
+                if (out[i - 1] != '/') { /* check if path ends with a slash */
+                        out[i++] = '/';
+                        out[i] = '\0';
+                }
+                strlcpy(&out[i], CONFIG_FOLDER, length - i);
+                return 0;
+        }
 
-	if (path[strlen(path) - 1] != '/') {
-		path = strcat(path, "/");
-	}
-
-	if (path) {
-		int i = strlcpy(out, path, length);
-		strlcpy(&out[i], CONFIG_FOLDER, length - i);
-		return 0;
-	}
-
-	return storage_from_home(out, length, CONFIG_PATH);
+        return storage_from_home(out, length, CONFIG_PATH);
 }
 
 int storage_download_path(char *out, size_t length) {

--- a/src/storage.c
+++ b/src/storage.c
@@ -81,6 +81,11 @@ int storage_path(char *out, size_t length) {
 	if (length > PATH_MAX) length = PATH_MAX;
 
 	path = getenv("XDG_CONFIG_HOME");
+
+	if (path[strlen(path) - 1] != '/') {
+		path = strcat(path, "/");
+	}
+
 	if (path) {
 		int i = strlcpy(out, path, length);
 		strlcpy(&out[i], CONFIG_FOLDER, length - i);


### PR DESCRIPTION
If the XDG_CONFIG_HOME env variable doesn't end with a slash, vgmi creates its config directory at ~/.configvgmi instead of ~/.config/vgmi . This patch attempts to fix this.