### PR TITLE
fix: add pthread.h header to bookmarks.h

### DIFF
--- a/src/bookmarks.h
+++ b/src/bookmarks.h
@@ -2,6 +2,8 @@
  * ISC License
  * Copyright (c) 2023 RMF <rawmonk@rmf-dev.com>
  */
+#include <pthread.h>
+
 int bookmark_load(void);
 int bookmark_rewrite(void);
 int bookmark_add(const char *url, const char *name);


### PR DESCRIPTION
Hi there!

I was trying to compile this for MacOS 15.6.1 and got this error for missing declarations: 

```shell

cc -DENABLE_SECCOMP_FILTER  -O2 -Wall -Wpedantic -Wextra -I./include -c src/bookmarks.c -o obj/bookmarks.o
In file included from src/about_newtab.c:11:
src/bookmarks.h:17:8: error: unknown type name 'pthread_mutex_t'; did you mean 'pthread_attr_t'?
   17 | extern pthread_mutex_t bookmark_mutex;
      |        ^~~~~~~~~~~~~~~
      |        pthread_attr_t
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/_pthread/_pthread_attr_t.h:31:33: note: 'pthread_attr_t' declared here
   31 | typedef __darwin_pthread_attr_t pthread_attr_t;
      |                                 ^
1 error generated.
```

This PR adds the `pthread.h` and allows me to compile on MacOS. 